### PR TITLE
HPESL-451:run-swci script not taking swci_init file

### DIFF
--- a/scripts/bin/run-swci
+++ b/scripts/bin/run-swci
@@ -129,7 +129,7 @@ onTrainEnd()
         [[ ! -f "${path}" ]] && \
             error "--init-script-name: ${initScriptName}: bad file"        
             
-        envvar+=(-e "STARTUP_SCRIPT=${initScriptName}")
+        envvar+=(-e "SWCI_STARTUP_SCRIPT=${initScriptName}")
     fi 
 
     cmd+=("${unprocessedOpts[@]}")


### PR DESCRIPTION
Fix for run-swci script not taking swci_init file.