### PR TITLE
Feature: podman support for swarm

### DIFF
--- a/scripts/bin/common
+++ b/scripts/bin/common
@@ -93,11 +93,15 @@ snImage="${swarmDockerHub}/${swarmOrg}/${snRepoName}:${swarmVer}"
 swciImage="${swarmDockerHub}/${swarmOrg}/${swciRepoName}:${swarmVer}"
 swopImage="${swarmDockerHub}/${swarmOrg}/${swopRepoName}:${swarmVer}"
 
-# We need elevated privileges to run docker commands, if the current user is not
-# a member of the docker group. Given, the user has configured password-less
-# sudo.
-id -Gn 2> /dev/null | grep "\(\<docker\>\)\|\(\<root\>\)" > /dev/null 2>&1
-[[ ${?} -ne 0 ]] && sudo="sudo"
+# If podman is installed we don't need elevate privileges so sudo or docker group not required 
+# else we need elevated privileges to run docker commands, if the current user is not
+# a member of the docker group. 
+# Given, the user has configured password-less sudo
+
+if ! command -v podman &>/dev/null; then
+    id -Gn 2> /dev/null | grep "\(\<docker\>\)\|\(\<root\>\)" > /dev/null 2>&1
+    [[ ${?} -ne 0 ]] && sudo="sudo"
+fi
 
 
 # Order of process and usage functions to call.
@@ -1226,6 +1230,7 @@ dockerRun()
         ${sudo} docker inspect -f '{{.Config.Image}}' ${containerIDVar}  >> ${CONTAINER_INFO_FILE}
         # .Image returns image id in format of sha256:<id>.
         ${sudo} docker inspect -f '{{.Image}}' ${containerIDVar}  >> ${CONTAINER_INFO_FILE}
+        chmod +r ${CONTAINER_INFO_FILE}  #so that non root user can also read it inside container e.g. in podman env
         # docker cp can copy to stopped container too
         ${sudo} docker cp ${CONTAINER_INFO_FILE} ${containerIDVar}:/tmp/container_info_file
         # Following are the sample contents of container_info_file file

--- a/scripts/bin/run-swop
+++ b/scripts/bin/run-swop
@@ -67,6 +67,10 @@ printComponentUsage()
     printf -- "\tThis file should be located inside the user directory, at the top-level itself.\n"
     printf -- "\tMandatory Parameter\n\n" 
 
+    printf -- "--docker-socket-file <docker socket file>\n"
+    printf -- "\tname of docker sock file.\n"
+    printf -- "\tDefault: ${containerDockerSock}\n\n"
+
     printf -- "--docker-group-id <numeric group-id>\n"
     printf -- "\tnumeric group id of the docker group \n"
     printf -- "\tthe docker group id to be used for SWOP user\n"
@@ -111,6 +115,11 @@ processComponentBatchOpt()
     case "${opt}" in
         --usr-dir) checkAndAssign "${opt}" "${optarg}";;            
         --profile-file-name) checkAndAssign "${opt}" "${optarg}";;
+        --docker-socket-file)
+            checkAndAssign "${opt}" "${optarg}"
+            dockerSocketFile="$(realpath -m "${optarg}")"
+            [[ ! -S "${dockerSocketFile}" ]] && error "${opt}: ${optarg}: bad docker socket file"
+            ;;            
         --docker-group-id) 
             checkAndAssign "${opt}" "${optarg}"
             re='^[0-9]+$'
@@ -143,8 +152,19 @@ onTrainEnd()
 
     [[ -n "$(realpath "${usrDir}")" ]] && appendArrayVar "" dockerOpts            \
         "--volume="$(realpath "${usrDir}")":${containerUsrDir}:rw"
-    
-    appendArrayVar "" dockerOpts "--volume=${containerDockerSock}:${containerDockerSock}:rw"
+
+    # If dockerSocketFile variable is empty and container runtime is podman try to set
+    # dockerSocketFile automatically from `podman info` command
+    # else set it to default path of docker runtime
+    if [[ -z ${dockerSocketFile} ]] && command -v podman &>/dev/null; then
+        dockerSocketFile=`podman info --format '{{.Host.RemoteSocket.Path}}'`
+    elif [[ -z ${dockerSocketFile} ]]
+        dockerSocketFile=${containerDockerSock}
+    fi
+
+    # -S Checks if socket exists and is of socket type
+    [[ -S "${dockerSocketFile}" ]] && appendArrayVar "" dockerOpts  \
+        "--volume=${dockerSocketFile}:${containerDockerSock}:rw"
 
     # If not passed assign the invoking user as the SWOP_UID
     [[ -z "${swopUid}" ]] && swopUid=$(id -u)


### PR DESCRIPTION
Changes:

1. updated `scripts/bin/common` script as `docker` group not required for podman
2. set correct owner of CONTAINER_INFO_FILE file in common script
3. Allow user to pass `docker-socket-file` in `run-swop`
4. added support for automatically getting podman socket path