### PR TITLE
pyt.py updates to reset model back to train mode after loss computation

### DIFF
--- a/lib/src/python-client/swarmlearning/pyt.py
+++ b/lib/src/python-client/swarmlearning/pyt.py
@@ -299,6 +299,7 @@ class SwarmCallback(SwarmCallbackBase):
         '''
         valLoss = 0
         totalMetrics = 0
+        model = self.mlCtx.model
         
         if(self.valData == None):
             return valLoss, totalMetrics
@@ -333,7 +334,7 @@ class SwarmCallback(SwarmCallbackBase):
             # Update the model, mertic and loss also to device specific object
             metricFunctionObj = metricFunctionObj.to(device)
             lossFunctionObj = lossFunctionObj.to(device)
-            model = self.mlCtx.model.to(device)
+            model = model.to(device)
             model.eval()
             
             with torch.no_grad():
@@ -357,8 +358,12 @@ class SwarmCallback(SwarmCallbackBase):
             self.logger.debug(f" Local Metrics: {self.metricFunction} on valData : {totalMetrics} \n")
             # Resetting internal state such that metric is ready for new data
             metricFunctionObj.reset()
+            # set model mode to train so that application code will continue its train process
+            model.train() 
         
         except Exception as emsg:
+            # set model mode to train so that application code will continue its train process
+            model.train()
             self._logAndRaiseError("Exception in method pyt.py:_calculateLocalLossAndMetrics, error message - %s"%(emsg))
         
         return valLoss, totalMetrics

--- a/lib/src/python-client/swarmlearning/pyt.py
+++ b/lib/src/python-client/swarmlearning/pyt.py
@@ -358,11 +358,11 @@ class SwarmCallback(SwarmCallbackBase):
             self.logger.debug(f" Local Metrics: {self.metricFunction} on valData : {totalMetrics} \n")
             # Resetting internal state such that metric is ready for new data
             metricFunctionObj.reset()
-            # set model mode to train so that application code will continue its train process
+            # set model mode to train so that application code can continue its train process
             model.train() 
         
         except Exception as emsg:
-            # set model mode to train so that application code will continue its train process
+            # set model mode to train so that application code can continue its train process
             model.train()
             self._logAndRaiseError("Exception in method pyt.py:_calculateLocalLossAndMetrics, error message - %s"%(emsg))
         


### PR DESCRIPTION

[pyt.tf](http://pyt.tf/) client module setting model mode to test for computing loss. It needs to be set back to train mode, otherwise user code might get into issues for continuous training process where user doesn't set model back to train mode.  
Observed the issue while testing differential privacy in pytorch. During differential privacy optimizer expects model to be in train mode, but due to this issue in client code it was throwing an issues.
ISSUE:  
File "model/cifar_first_stage.py", line 129, in doTrainBatchPvc  
loss.backward()  
File "/opt/conda/lib/python3.7/site-packages/torch/_tensor.py", line 489, in backward